### PR TITLE
Refactor: Extract methods from Renderer.draw() function

### DIFF
--- a/js/renderer.js
+++ b/js/renderer.js
@@ -1,22 +1,48 @@
 export const Renderer = {
     draw(board, container, handleLeftClick, handleRightClick) {
-        container.innerHTML = "";
-        container.style.gridTemplateColumns = `repeat(${board.cols}, 30px)`;
+        this.clearContainer(container);
+        this.setupGridLayout(container, board.cols);
+        this.createCells(board, container, handleLeftClick, handleRightClick);
+    },
 
+    clearContainer(container) {
+        container.innerHTML = "";
+    },
+
+    setupGridLayout(container, cols) {
+        container.style.gridTemplateColumns = `repeat(${cols}, 30px)`;
+    },
+
+    createCells(board, container, handleLeftClick, handleRightClick) {
         for (let r = 0; r < board.rows; r++) {
             for (let c = 0; c < board.cols; c++) {
-                const cell = document.createElement("div");
-                cell.className = "cell";
-                cell.dataset.row = r;
-                cell.dataset.col = c;
-                cell.addEventListener("click", () => handleLeftClick(r, c));
-                cell.addEventListener("contextmenu", (e) => {
-                    e.preventDefault();
-                    handleRightClick(r, c);
-                });
+                const cell = this.createCell(r, c, handleLeftClick, handleRightClick);
                 container.appendChild(cell);
             }
         }
+    },
+
+    createCell(row, col, handleLeftClick, handleRightClick) {
+        const cell = document.createElement("div");
+        
+        this.setCellProperties(cell, row, col);
+        this.attachCellEventListeners(cell, row, col, handleLeftClick, handleRightClick);
+        
+        return cell;
+    },
+
+    setCellProperties(cell, row, col) {
+        cell.className = "cell";
+        cell.dataset.row = row;
+        cell.dataset.col = col;
+    },
+
+    attachCellEventListeners(cell, row, col, handleLeftClick, handleRightClick) {
+        cell.addEventListener("click", () => handleLeftClick(row, col));
+        cell.addEventListener("contextmenu", (e) => {
+            e.preventDefault();
+            handleRightClick(row, col);
+        });
     },
 
     getCell(r, c) {


### PR DESCRIPTION
Summary
Refactored the monolithic draw() method in the Renderer object by extracting logical operations into separate, focused methods to improve code maintainability and readability while preserving all existing functionality.
Changes Made
Code Structure Improvements

Extracted container management into clearContainer() and setupGridLayout() methods
Separated cell creation logic into createCells() and createCell() methods
Isolated property setting into setCellProperties() method
Centralized event handling into attachCellEventListeners() method

Benefits
Maintainability

✅ Each method has a single, clear responsibility
✅ Reduced complexity of main draw method
✅ Easier to modify individual operations without affecting others
✅ Better separation of DOM manipulation concerns

Testability

✅ Individual methods can be unit tested in isolation
✅ Event listener logic can be tested separately
✅ Grid setup and cell creation can be tested independently
✅ Easier to mock DOM elements for testing

Readability

✅ Self-documenting method names explain intent
✅ Reduced cognitive load when reading the main flow
✅ Clear separation between layout setup and cell creation
✅ Easier to understand event binding logic

Code Reusability

✅ Cell creation methods can be reused for dynamic updates
✅ Event handling logic is centralized and consistent
✅ Layout setup is modular and configurable
